### PR TITLE
Membership

### DIFF
--- a/src/pages/SignUpPage.jsx
+++ b/src/pages/SignUpPage.jsx
@@ -74,7 +74,6 @@ const SignUpPage = () => {
     if(password !== confirmPassword) {
       setMismatchPassword(true);
       setIsSubmitting(false);
-      return;
     }
     try {
       const { data: existEmail } = await supabase
@@ -83,20 +82,19 @@ const SignUpPage = () => {
         .eq('email', email)
         .single();
 
-      if (existEmail) {
-        setEmailError(true);
-        setIsSubmitting(false);
-        return;
-      }
-
       const {data: existNickname } = await supabase
       .from('users')
       .select('nickname')
       .eq('nickname', nickname)
       .single();
 
-      if(existNickname) {
-        setNicknameError(true);
+      if(existEmail || existNickname) {
+        if(existEmail) {
+          setEmailError(true);
+        }
+        if(existNickname) {
+          setNicknameError(true);
+        }
         setIsSubmitting(false);
         return;
       }
@@ -122,7 +120,6 @@ const SignUpPage = () => {
       alert(`회원가입이 완료되었습니다. ${nickname}님 환영합니다!`);
     } catch (error) {
       console.error('회원가입 오류 발생', error);
-      alert("이미 존재하는 이메일입니다! 다른 이메일을 입력해주세요.")
     } finally {
       setIsSubmitting(false);
     }
@@ -160,7 +157,7 @@ const SignUpPage = () => {
           onChange={(e) => setEmail(e.target.value)}
           required
         />
-        {emailError && <DoubleCheck>이미 사용 중인 이메일입니다 다른 이메일을 입력해주세요.</DoubleCheck>}
+        {emailError && <DoubleCheck>이미 사용 중인 이메일입니다. 다른 이메일을 입력해주세요.</DoubleCheck>}
         <Input
           type="password"
           name="password"
@@ -177,7 +174,7 @@ const SignUpPage = () => {
           onChange={(e) => setConfirmPassword(e.target.value)}
           required
         />
-        {mismatchPassword && <DoubleCheck>비밀번호가 일치하지 않습니다 다시 입력해주세요.</DoubleCheck>}
+        {mismatchPassword && <DoubleCheck>비밀번호가 일치하지 않습니다. 다시 입력해주세요.</DoubleCheck>}
         <Input
           type="text"
           name="nickname"
@@ -186,7 +183,7 @@ const SignUpPage = () => {
           onChange={(e) => setNickname(e.target.value)}
           required
         />
-        {nicknameError && <DoubleCheck>이미 사용 중인 닉네임입니다 다른 닉네임을 사용해주세요.</DoubleCheck>}
+        {nicknameError && <DoubleCheck>이미 사용 중인 닉네임입니다. 다른 닉네임을 사용해주세요.</DoubleCheck>}
         <Button type="submit" disabled={isSubmitting}>
           {isSubmitting ? '가입 중...' : '회원가입'}
         </Button>


### PR DESCRIPTION
회원가입 절차에서 중복된 이메일, 중복된 닉네임을 사용해도 중복된 이메일에 대한 경고 문구만 출력되고 중복된 닉네임에 대한 경고 문구는 출력이 안되는 오류가 있었는데, 이는 중복된 이메일에 대한 경고 문구를 출력하는 과정에서 경고 문구를 출력하면 return을 시켜버려서 그 아래에 짜여진 닉네임 중복 확인 경고 문구 출력 기능에 대한 코드는 작동을 안했던 거라서 논리연산자를 사용해 중복 확인 절차를 동시에 수행할 수 있도록 수정을 함으로써 오류를 해결했습니다.