### PR TITLE
fix: HomeFeed, CommitDetail 닉네임을 auth -> users 테이블에서 받아 렌더링 하도록  수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,20 @@
 import { useEffect, useState } from 'react';
 import GlobalStyles from './Globalstyles';
-import FetchData from './components/FetchData';
+import { FetchData, FetchUsers } from './components/FetchData';
 import Router from './shared/Router';
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  'https://nozekgjgeindgyulfapu.supabase.co',
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5vemVrZ2pnZWluZGd5dWxmYXB1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3MTcxNDI1MDEsImV4cCI6MjAzMjcxODUwMX0.Wu1dt8WSMSro-_ieydr-ghmfcKPr568Ovm6dfzgrB00'
-);
+import supabase from './supabaseClient';
 
 const App = () => {
   const [posts, setPosts] = useState([]);
   const [signIn, setSignIn] = useState(false);
+  const [users, setUsers] = useState([]);
 
   const handleDataFetch = (data) => {
     setPosts(data);
+  };
+
+  const handleUsersFetch = (data) => {
+    setUsers(data)
   };
 
 
@@ -43,8 +43,13 @@ const App = () => {
       const { data } = await supabase.from('posts').select();
       setPosts(data);
     };
+    const fetchUsers = async () => {
+      const { data } = await supabase.from('users').select();
+      setUsers(data);
+    }
 
     fetchData();
+    fetchUsers();
     checkSignIn();
 
     const { data: authListener } = supabase.auth.onAuthStateChange(() => {
@@ -59,8 +64,9 @@ const App = () => {
   return (
     <>
       <GlobalStyles />
-      <FetchData onDataFetch={handleDataFetch} />
-      <Router posts={posts} signIn={signIn} setSignIn={setSignIn} signOut={signOut}/>
+      <FetchData onDataFetch={handleDataFetch}/>
+      <FetchUsers handleUsersFetch={handleUsersFetch}/>
+      <Router posts={posts} users={users} signIn={signIn} setSignIn={setSignIn} signOut={signOut}/>
     </>
   );
 };

--- a/src/components/FetchData.jsx
+++ b/src/components/FetchData.jsx
@@ -19,4 +19,22 @@ const FetchData = ({ onDataFetch }) => {
   return null;
 };
 
-export default FetchData;
+const FetchUsers = ({ handleUsersFetch }) => {
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data, error } = await supabase.from('users').select('*');
+      if (error) {
+        console.log('유저 테이블 못 불러옴 => ', error);
+      } else {
+        console.log('유저 테이블 잘 불러옴 => ', data);
+        handleUsersFetch(data);
+      }
+    };
+
+    fetchData();
+  }, []); // 일단 마운트 시
+
+  return null;
+};
+
+export { FetchData, FetchUsers } ;

--- a/src/components/HomeFeed.jsx
+++ b/src/components/HomeFeed.jsx
@@ -140,7 +140,6 @@ const HomeFeed = ({ posts }) => {
             <HomePostImage src={post.image} />
             <HomePostOverlay>
               <HomePostTitle>{post.title}</HomePostTitle>
-              {/* <HomePostNickname>{post.nickname}</HomePostNickname> */}
               <HomePostNickname>{post.nickname}</HomePostNickname>
               <HomePostContent>{post.content}</HomePostContent>
             </HomePostOverlay>

--- a/src/pages/CommitDetail.jsx
+++ b/src/pages/CommitDetail.jsx
@@ -117,7 +117,7 @@ const ButtonGroup = styled.div`
   margin-top: 20px;
 `;
 
-const CommitDetail = () => {
+const CommitDetail = ({users}) => {
   const navigate = useNavigate(); // 홈으로 넘기기 위한 훅
   const location = useLocation(); // HomeFeed 컴포넌트에서 글 내용을 넘겨받기 위한 훅(edit 함수에서)
   const { id, title, content, user_id } = location.state || {};
@@ -131,8 +131,9 @@ const CommitDetail = () => {
   const [titleError, setTitleError] = useState(''); // 제목 에러 메시지 띄우기 위해 상태로 관리
   const [contentError, setContentError] = useState(''); // 내용 에러 메시지 띄우기 위해 상태로 관리
   const [user, setUser] = useState(null); // 사용자 정보 상태 변수와 상태 변경 함수 지정
-
   // 글쓰기 페이지가 처음 렌더링 될 때 사용자가 로그인했는지 확인
+  const [matchedNickName ,setMatchedNickName] = useState('');
+
   useEffect(() => {
     const checkUser = async () => {
       const {
@@ -141,7 +142,16 @@ const CommitDetail = () => {
       // 유저 정보가 있어야만 글쓰기 페이지를 보여줍니다.
       if (user) {
         console.log('수파베이스에서 받아온 유저의 상태:', user);
-        console.log('닉네임:', user.user_metadata.nickname);
+        console.log('users 테이블에서 받아온 유저의 닉네임:', users);
+        console.log('수파베이스 auth_nickname:', user.user_metadata.nickname);
+
+        let matchedUser = users.find(u => u.id === user.id);
+        if (matchedUser) {
+          console.log('users에서 찾은 이 유저의 닉네임은요 => ', matchedUser.nickname);
+          setMatchedNickName(matchedUser.nickname);
+        } else {
+          console.log('users 테이블에서 이 유저의 닉네임을 못찾았습니다요');
+        }
         setUser(user); // 받아온 사용자 정보로 user 상태를 업데이트
         // 유저 정보가 없으면 로그인 페이지로 넘깁니다.
       } else {
@@ -178,7 +188,7 @@ const CommitDetail = () => {
     // supabase 테이블에 넣기 위한 유효성 검사 규칙은 아직 모릅니다.
     // 저의 편의상 추가한 유효성 검사입니다.
     let valid = true;
-    const nickname = user.user_metadata.nickname;
+    const nickname = matchedNickName;
 
     // 제목 길이가 40자 미만이면 유효성 검사 false로 바꾸고 에러 메시지 출력.
     if (postTitle.length > 50) {
@@ -291,8 +301,7 @@ const CommitDetail = () => {
         </EditorContainer>
         {contentError && <ErrorMessage>{contentError}</ErrorMessage>}
         <ButtonGroup>
-          {/* <Button onClick={handleSubmit}>등록</Button> */}
-          <Button type="submit">수정</Button>
+          <Button type="submit">등록</Button>
           <CancelButton onClick={handleCancel}>취소</CancelButton>
         </ButtonGroup>
       </Form>

--- a/src/shared/Router.jsx
+++ b/src/shared/Router.jsx
@@ -9,17 +9,14 @@ import LoginPage from '../pages/LoginPage';
 import SignUpPage from '../pages/SignUpPage';
 import HomeHeader from '../components/HomeHeader';
 
-const Router = ({ posts, comments, signIn, setSignIn, signOut }) => {
+const Router = ({ posts, users, comments, signIn, setSignIn, signOut }) => {
   return (
     <BrowserRouter>
     <HomeHeader signIn={signIn} signOut={signOut}/>
       <Routes>
-        <Route path="/" element={<Home posts={posts}/>} />
+        <Route path="/" element={<Home posts={posts} users={users}/>} />
         <Route path="/mypage" element={signIn ? <MyPage/> : <Navigate to="/login" />} />
-        <Route path="/commitdetail" element={signIn ? <CommitDetail/> : <Navigate to="/login"/>}  />
-        <Route path="/detailpage/:detailId" element={signIn ? <DetailPage/> : <Navigate to="/login" />} />
-
-        <Route path="/test" element={<Test posts={posts} />} />
+        <Route path="/commitdetail" element={signIn ? <CommitDetail users={users}/> : <Navigate to="/login"/>}  />
         <Route path="/detailpage" element={signIn ? <DetailPage/> : <Navigate to="/login" />} />
         <Route path="/test" element={<Test posts={posts} comments={comments} />} />
         <Route path="/login" element={<LoginPage signIn={signIn} setSignIn={setSignIn} signOut={signOut}/>} />


### PR DESCRIPTION
1. CommitDetail 페이지 '수정'으로 렌더링 한 버튼을 '등록'으로 문구 수정
2. 최상위 컴포넌트에서 Users 테이블을 fetch로 받아와 회원 정보를 하위 컴포넌트로 props로 내림.
3. users 테이블의 유저 객체를 기반으로 '작성 시점에서의 작성자 닉네임'을 posts 테이블에 기록하고 HomeFeed와 CommitDetail에 렌더링 되도록 수정